### PR TITLE
Update 'wadoget' method in ecg.py

### DIFF
--- a/ecg/ecg.py
+++ b/ecg/ecg.py
@@ -56,7 +56,8 @@ class ECG(object):
         def wadoget(stu, ser, obj):
 
             payload = {'requestType': 'WADO', 'studyUID': stu,
-                       'seriesUID': ser, 'objectUID': obj}
+                       'seriesUID': ser, 'objectUID': obj,
+                       'contentType': 'application/dicom'}
             headers = {'content-type': 'application/json'}
 
             resp = requests.get(wadosrv, params=payload, headers=headers)


### PR DESCRIPTION
Explicitly set the GET variable 'contentType' in method wadoget, due to recent issues with some WADO services
